### PR TITLE
#63ブラウザ拡張を更新した際に、データのリセット処理をなくす

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -22,14 +22,11 @@ bg.pageCallUpdateInfo = async() => {
 	return new Promise(async (resolve) => {
 		console.log("call pageCallUpdateInfo");
 		await Time();
-		let manHourInfo = await getLocalStorage();
+		let manHourInfo = await getManHourInfo();
 		const keys = Object.keys(manHourInfo);
         for (let key of keys) {
-            if(key != "currentManHourIndex"  && key != "localStorage" && key != "startTime") {
-                console.log(key)
-				manHourInfo[key]["formIndex"] = 1;
-				await setLocalStorage(manHourInfo[key]["no"], manHourInfo[key]);
-            }
+			manHourInfo[key]["formIndex"] = 1;
+			await setLocalStorage(manHourInfo[key]["no"], manHourInfo[key]);
         }
 		console.log(manHourInfo);
 		resolve(manHourInfo);
@@ -73,6 +70,14 @@ bg.getCurrentManHourInfo = async () => {
 			let currentManHourInfo = await getLocalStorage(index);
 			resolve(currentManHourInfo[index]);
 		}
+	})
+}
+
+bg.getAllManHourInfo = async () => {
+	console.log("call bg.getAllManHourInfo");
+	return new Promise(async(resolve) => {
+		let manHourInfo = await getManHourInfo();
+		resolve(manHourInfo);
 	})
 }
 
@@ -243,7 +248,7 @@ bg.clickResetButton = async(undefined) => {
 				});
 			}
 		}
-		resolve(await getLocalStorage());
+		resolve(await getManHourInfo());
 	});
 };
 

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -22,7 +22,7 @@ bg.pageCallUpdateInfo = async() => {
 	return new Promise(async (resolve) => {
 		console.log("call pageCallUpdateInfo");
 		await Time();
-		let manHourInfo = await getManHourInfo();
+		let manHourInfo = await getAllManHourInfo();
 		const keys = Object.keys(manHourInfo);
         for (let key of keys) {
 			manHourInfo[key]["formIndex"] = 1;
@@ -76,7 +76,7 @@ bg.getCurrentManHourInfo = async () => {
 bg.getAllManHourInfo = async () => {
 	console.log("call bg.getAllManHourInfo");
 	return new Promise(async(resolve) => {
-		let manHourInfo = await getManHourInfo();
+		let manHourInfo = await getAllManHourInfo();
 		resolve(manHourInfo);
 	})
 }
@@ -248,7 +248,7 @@ bg.clickResetButton = async(undefined) => {
 				});
 			}
 		}
-		resolve(await getManHourInfo());
+		resolve(await getAllManHourInfo());
 	});
 };
 

--- a/browser-extension/js/background/event.js
+++ b/browser-extension/js/background/event.js
@@ -8,7 +8,7 @@
  * 押したら、計測している工数が止まる ContextMenusを作成
  * localStorageのデータを削除
  */
-chrome.runtime.onInstalled.addListener(detail => {
+chrome.runtime.onInstalled.addListener(async(detail) => {
 	if (detail.reason == "install" || detail.reason == "update") {
 		createContextMenus({
 			"id": "manhour-management",
@@ -22,7 +22,18 @@ chrome.runtime.onInstalled.addListener(detail => {
 			"type" : "normal",
 			"contexts" : ["all"]
 		});
-		chrome.storage.local.clear();
+		getManHourInfo().then((manHourInfo) => {
+			const keys = Object.keys(manHourInfo);
+			for (let key of keys) {
+				createContextMenus({
+					"id": key,
+					"title" : manHourInfo[key]["name"],
+					"parentId": "manhour-management",
+					"type" : "normal",
+					"contexts" : ["all"]
+				});
+			}
+		})
 	}
 });
 

--- a/browser-extension/js/background/localStorage.js
+++ b/browser-extension/js/background/localStorage.js
@@ -21,7 +21,7 @@ const removeLocalStorage = (key) => new Promise((resolve, reject) => {
 	})
 });
 
-const getManHourInfo = () => new Promise((resolve) => {
+const getAllManHourInfo = () => new Promise((resolve) => {
 	chrome.storage.local.get(null, (data) => {
 		const keys = Object.keys(data);
 		for (let key of keys) {

--- a/browser-extension/js/background/localStorage.js
+++ b/browser-extension/js/background/localStorage.js
@@ -21,6 +21,20 @@ const removeLocalStorage = (key) => new Promise((resolve, reject) => {
 	})
 });
 
+const getManHourInfo = () => new Promise((resolve) => {
+	chrome.storage.local.get(null, (data) => {
+		const keys = Object.keys(data);
+		for (let key of keys) {
+			// 数字か否かの判定 (工数のkeyは数字であるため)
+            if(isNaN(key)) {
+                // 工数情報以外のデータを削除
+                delete data[key];
+            }
+		}
+		resolve(data);
+	})
+});
+
 const getTotalTime = () => new Promise((resolve, reject) => {
 	chrome.storage.local.get(null, (data) => {
 		let totalTime = 0;

--- a/browser-extension/js/popup/popup.js
+++ b/browser-extension/js/popup/popup.js
@@ -13,16 +13,14 @@ let intervalForTimer;
         const rootDiv = document.getElementById("root");
         let totalTime = 0;
         for (let key of keys) {
-            if(key != "currentManHourIndex" && key != "time" && key != "localStorage" && key != "startTime") {
-                // 各工数の時間を更新する
-                embeddingManHour(
-                    manHourInfo[key]["name"], 
-                    manHourInfo[key]["no"], 
-                    getTime(manHourInfo[key]["time"]+manHourInfo[key]["diffTime"]), 
-                    rootDiv);
-                // 合計時間を加算する
-                totalTime += manHourInfo[key]["time"]+manHourInfo[key]["diffTime"]
-            }
+            // 各工数の時間を更新する
+            embeddingManHour(
+                manHourInfo[key]["name"], 
+                manHourInfo[key]["no"], 
+                getTime(manHourInfo[key]["time"]+manHourInfo[key]["diffTime"]), 
+                rootDiv);
+            // 合計時間を加算する
+            totalTime += manHourInfo[key]["time"]+manHourInfo[key]["diffTime"]
         }
         // 合計時間を更新する
         updateTotalTime(getTime(totalTime));
@@ -109,7 +107,8 @@ document.addEventListener('DOMContentLoaded', function() {
     // リセットボタンを押したとき
     document.querySelector('.reset').addEventListener('click', async ()=>{
         clearInterval(intervalForTimer);
-        await bg.clickResetButton().then((manHourInfo) =>{
+        await bg.clickResetButton();
+        bg.getAllManHourInfo().then((manHourInfo) =>{
             emmbedingHtml(manHourInfo);
         });
         // 合計時間をリセットする


### PR DESCRIPTION
データリセットの修正
全ての工数情報を取得する処理を一箇所にまとめた

面倒臭い条件分岐があった部分を削除できて満足